### PR TITLE
Update EmbedCollaboratorPayloadDialog.java

### DIFF
--- a/src/main/java/com/blackberry/jwteditor/view/dialog/operations/EmbedCollaboratorPayloadDialog.java
+++ b/src/main/java/com/blackberry/jwteditor/view/dialog/operations/EmbedCollaboratorPayloadDialog.java
@@ -69,11 +69,18 @@ public class EmbedCollaboratorPayloadDialog extends AbstractDialog {
 
     private void onOK() {
         String selectedLocation = (String) comboBoxAlgorithm.getSelectedItem();
+        String JWK_URL = "";
+
+                if("jku".equals(selectedLocation)) {
+                    JWK_URL = "https://" + collaboratorPayloadGenerator.generatePayload().toString() + "/jwks.json";
+                } else if("x5u".equals(selectedLocation)) {
+                    JWK_URL = "https://" + collaboratorPayloadGenerator.generatePayload().toString() + "/cert.pem";
+                }
 
         jws = Attacks.embedCollaboratorPayload(
                 jws,
                 selectedLocation,
-                collaboratorPayloadGenerator.generatePayload().toString()
+                JWK_URL
         );
 
         dispose();


### PR DESCRIPTION
Hello, when generating "jku" and "x5u" headers using the JWT-Editor extension, the URL is incorrectly generated without utilizing the schemas "https://" or "http://". Instead, it generates the URL with only the Burp Collaborator information, causing the application to misinterpret them.

<img width="994" alt="1" src="https://github.com/PortSwigger/jwt-editor/assets/96009982/5ecf0517-f7f1-4d60-8a48-4f27619bd278">

<img width="860" alt="2" src="https://github.com/PortSwigger/jwt-editor/assets/96009982/9ae6683e-20a9-4d83-bd4c-e2fa4faaf122">

The solution that resolved this issue for me has added the "https://" schema to the beginning of the collaborator's URLs and appended "/jwks.json" and "/cert.pem" to distinguish which header was vulnerable, whether it was "jku" or "x5u." This adjustment enables an attacker to differentiate between the two through Burp Collaborator.

<img width="972" alt="3" src="https://github.com/PortSwigger/jwt-editor/assets/96009982/cc60ae94-a852-414a-944b-929b5064209f">

<img width="947" alt="4" src="https://github.com/PortSwigger/jwt-editor/assets/96009982/21e6b315-80a1-4cac-aea4-89bafadb17e2">