### PR TITLE
Update AnnotationsModifier.java

### DIFF
--- a/src/main/java/burp/proxy/AnnotationsModifier.java
+++ b/src/main/java/burp/proxy/AnnotationsModifier.java
@@ -48,7 +48,9 @@ class AnnotationsModifier {
         Counts counts = countJOSEObjects(messageString);
 
         if (!counts.isZero()) {
-            annotations.setHighlightColor(proxyConfig.highlightColor().burpColor);
+            if (proxyConfig.highlightJWT()){
+                annotations.setHighlightColor(proxyConfig.highlightColor().burpColor);
+            }
             annotations.setNotes(counts.comment());
         }
     }


### PR DESCRIPTION
This fixes JWT editor highlighting request/responses with JWTs even when the "Highlight JWTs within HTTP and WebSocket messages" checkbox isn't checked. Added functionality to the updateAnnotations function that checks if JWTs are to be highlighted before highlighting them.